### PR TITLE
Enhanced BaseChatCommand class to handle multiple targets simultaneously

### DIFF
--- a/ColonyPlusPlus/ColonyPlusPlus/Classes/BaseChatCommand.cs
+++ b/ColonyPlusPlus/ColonyPlusPlus/Classes/BaseChatCommand.cs
@@ -55,7 +55,7 @@ namespace ColonyPlusPlus.Classes
 
                 if (targets.Count == 0)
                 {
-                    Chat.Send(ply, "Player not found");
+                    Chat.Send(ply, $"Player {commandParameters[0]} not found");
                     return true;
                 }
                 return RunCommand(ply, commandParameters, targets.ToArray());

--- a/ColonyPlusPlus/ColonyPlusPlus/Classes/BaseChatCommand.cs
+++ b/ColonyPlusPlus/ColonyPlusPlus/Classes/BaseChatCommand.cs
@@ -46,15 +46,11 @@ namespace ColonyPlusPlus.Classes
                     return true;
                 }
                 var targets = new List<NetworkID>();
-                commandParameters.All(x =>
+                commandParameters.ToList().ForEach(x =>
                 {
                     Players.Player targetPlayer;
                     if (!String.IsNullOrEmpty(x) && Players.TryMatchName(x, out targetPlayer))
-                    {
                         targets.Add(targetPlayer.ID);
-                    }
-
-                    return false;
                 });
 
                 if (targets.Count == 0)

--- a/ColonyPlusPlus/ColonyPlusPlus/Classes/BaseChatCommand.cs
+++ b/ColonyPlusPlus/ColonyPlusPlus/Classes/BaseChatCommand.cs
@@ -33,7 +33,7 @@ namespace ColonyPlusPlus.Classes
                 if (Managers.ChatCommandManager.ChatCommandsList.TryGetValue(ChatCommandPrefix + " " + commandParameters[0], out newCommand))
                     return newCommand.TryDoCommand(ply, chatItem);
 
-                Chat.Send(ply, "Command " + commandParameters[0] + " is not a part of " + ChatCommandPrefix);
+                Chat.Send(ply, $"Command {commandParameters[0]} is not a part of {ChatCommandPrefix}");
                 return true;
             }
 

--- a/ColonyPlusPlus/ColonyPlusPlus/Classes/BaseChatCommand.cs
+++ b/ColonyPlusPlus/ColonyPlusPlus/Classes/BaseChatCommand.cs
@@ -22,88 +22,53 @@ namespace ColonyPlusPlus.Classes
 
         public bool TryDoCommand(Players.Player ply, string chatItem)
         {
-            string[] splits = chatItem.Split(' ');
+            var commandParameters = Helpers.Chat.ParseChatCommand(chatItem, ChatCommandPrefix);
+
             if (isMasterCommand)
             {
-                if (splits.Length <= 1)
-                {
+                if (commandParameters.Length == 0)
                     return false;
-                }
+
                 BaseChatCommand newCommand;
-                if (Managers.ChatCommandManager.ChatCommandsList.TryGetValue(splits[0] + " " + splits[1], out newCommand))
+                if (Managers.ChatCommandManager.ChatCommandsList.TryGetValue(ChatCommandPrefix + " " + commandParameters[0], out newCommand))
                     return newCommand.TryDoCommand(ply, chatItem);
-                else
-                {
-                    Chat.Send(ply, "Command " + splits[1] + " is not a part of " + splits[0]);
-                    return true;
-                }
+
+                Chat.Send(ply, "Command " + commandParameters[0] + " is not a part of " + ChatCommandPrefix);
+                return true;
             }
-            int cuts = ChatCommandPrefix.Split(' ').Length;
-            string[] cutsplits = new string[splits.Length - cuts];
-            for (int i = 0; i < cutsplits.Length; i++)
-            {
-                cutsplits[i] = splits[i + cuts];
-            }
+
             if (isTargetingCommand)
             {
-                string[] newsplits = splits;
-                if (cutsplits.Length == 0)
+
+                if (commandParameters.Length == 0)
                 {
                     Chat.Send(ply, "This command requires a target.");
                     return true;
                 }
-                NetworkID target = GetSubject(cutsplits, out newsplits);
-                
-                if (target == NetworkID.Invalid)
+                var targets = new List<NetworkID>();
+                commandParameters.All(x =>
                 {
-                    Chat.Send(ply, "Player " + cutsplits[0] + " not found.");
+                    Players.Player targetPlayer;
+                    if (!String.IsNullOrEmpty(x) && Players.TryMatchName(x, out targetPlayer))
+                    {
+                        targets.Add(targetPlayer.ID);
+                    }
+
+                    return false;
+                });
+
+                if (targets.Count == 0)
+                {
+                    Chat.Send(ply, "Player not found");
                     return true;
                 }
-                return RunCommand(ply, newsplits, target);
+                return RunCommand(ply, commandParameters, targets.ToArray());
             }
-            return RunCommand(ply, cutsplits, NetworkID.Invalid);
+            return RunCommand(ply, commandParameters, new NetworkID[0]);
         }
 
-        protected abstract bool RunCommand(Players.Player id, string[] args, NetworkID target);
+        protected abstract bool RunCommand(Players.Player id, string[] args, NetworkID[] targets);
 
-        private static NetworkID GetSubject(string[] argsBefore, out string[] argsAfter)
-        {
-            argsAfter = argsBefore;
-            if (argsBefore.Length < 1)
-            {
-                return NetworkID.Invalid;
-            }
-            Players.Player player;
-            int spacer = 0;
-            if (argsBefore[0].StartsWith("\"") && !(argsBefore[1].EndsWith("\"")))
-            {
-                string total = argsBefore[0];
-                while (!(argsBefore[1 + spacer].EndsWith("\"")))
-                {
-                    total += " " + argsBefore[1 + spacer];
-                    spacer++;
-                    if (spacer + 1 >= argsBefore.Length)
-                    {
-                        return NetworkID.Invalid;
-                    }
-                }
-                total += " " + argsBefore[1 + spacer];
-                spacer++;
-                argsAfter[0] = total;
-            }
-            argsAfter[0] = argsAfter[0].Trim('"');
-            if (Players.TryMatchName(argsAfter[0], out player))
-            {
-                string name = argsAfter[0];
-                argsAfter = new string[argsAfter.Length - spacer];
-                argsAfter[0] = name;
-                for (int i = 1 + spacer; i < argsBefore.Length; i++)
-                {
-                    argsAfter[i - spacer] = argsBefore[i];
-                }
-                return player.ID;
-            }
-            return NetworkID.Invalid;
-        }
+        
     }
 }

--- a/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Ban.cs
+++ b/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Ban.cs
@@ -11,11 +11,11 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
         {
         }
 
-        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             if (PermissionsManager.CheckAndWarnPermission(ply, "ban"))
             {
-                var targetPlayer = Players.GetPlayer(target);
+                var targetPlayer = Players.GetPlayer(targets[0]);
                 BlackAndWhitelisting.AddBlackList(targetPlayer.ID.steamID.m_SteamID);
 
                 var reason = "";
@@ -38,12 +38,12 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
         {
         }
 
-        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             if (PermissionsManager.CheckAndWarnPermission(ply, "unban"))
             {
                 //TODO: Log unbans
-                var targetPlayer = Players.GetPlayer(target);
+                var targetPlayer = Players.GetPlayer(targets[0]);
                 Classes.Managers.BanManager.removeBan(targetPlayer.ID);
                 BlackAndWhitelisting.RemoveBlackList(targetPlayer.ID.steamID.m_SteamID);
                 Chat.send(ply, $"Unbanned {targetPlayer.Name}", Chat.ChatColour.cyan);

--- a/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Chunk.cs
+++ b/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Chunk.cs
@@ -15,7 +15,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
 
         }
 
-        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             return false;
         }
@@ -28,7 +28,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
 
         }
 
-        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             if (PermissionsManager.CheckAndWarnPermission(ply, "chunk.claim") && Classes.Managers.ConfigManager.getConfigBoolean("chunks.enabled"))
             {
@@ -74,7 +74,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
 
         }
 
-        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             if (PermissionsManager.CheckAndWarnPermission(ply, "chunk.claim"))
             {
@@ -111,7 +111,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
 
         }
 
-        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             if (PermissionsManager.CheckAndWarnPermission(ply, "chunk.delete"))
             {
@@ -147,7 +147,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
 
         }
 
-        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             if (PermissionsManager.CheckAndWarnPermission(ply, "chunk.list") && Classes.Managers.ConfigManager.getConfigBoolean("chunks.enabled"))
             {
@@ -189,7 +189,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
 
         }
 
-        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             if (PermissionsManager.CheckAndWarnPermission(ply, "chunk.info") && Classes.Managers.ConfigManager.getConfigBoolean("chunks.enabled"))
             {

--- a/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Clear.cs
+++ b/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Clear.cs
@@ -12,7 +12,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
 
         }
 
-        override protected bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        override protected bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             if (PermissionsManager.CheckAndWarnPermission(ply, "cheats.clear"))
             {

--- a/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Creative.cs
+++ b/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Creative.cs
@@ -14,7 +14,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
 
         }
 
-        override protected bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        override protected bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             if (PermissionsManager.CheckAndWarnPermission(ply, "cheats.creative"))
             {

--- a/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Debug.cs
+++ b/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Debug.cs
@@ -14,7 +14,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
 
         }
 
-		protected override bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+		protected override bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
 		{
 			return false;
 		}
@@ -30,7 +30,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
             
         }
 
-		override protected bool RunCommand(Players.Player player, string[] args, NetworkID target)
+		override protected bool RunCommand(Players.Player player, string[] args, NetworkID[] targets)
 		{
 			if (PermissionsManager.CheckAndWarnPermission(player, "debug") && Classes.Managers.ConfigManager.getConfigBoolean("debug.enabled"))
 			{

--- a/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Kick.cs
+++ b/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Kick.cs
@@ -9,11 +9,11 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
         {
         }
 
-        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             if (PermissionsManager.CheckAndWarnPermission(ply, "kick"))
             {
-                var targetPlayer = Players.GetPlayer(target);
+                var targetPlayer = Players.GetPlayer(targets[0]);
                 ServerManager.Disconnect(targetPlayer);
                 Chat.send(ply, $"Kicked {targetPlayer.Name}",Chat.ChatColour.magenta);
             }

--- a/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Locate.cs
+++ b/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Locate.cs
@@ -10,11 +10,11 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
         {
         }
 
-        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             if (PermissionsManager.CheckAndWarnPermission(ply, "locate"))
             {
-                var player = Players.GetPlayer(target);
+                var player = Players.GetPlayer(targets[0]);
                 var status = player.IsConnected ? "online" : "offline";
 
                 Chat.sendSilent(ply,
@@ -32,11 +32,11 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
         {
         }
 
-        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             if (PermissionsManager.CheckAndWarnPermission(ply, "locate"))
             {
-                var player = Players.GetPlayer(target);
+                var player = Players.GetPlayer(targets[0]);
 
                 var banner = (from b in BannerTracker.GetBanners()
                     where b.Owner == player

--- a/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Online.cs
+++ b/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Online.cs
@@ -15,7 +15,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
 
         }
 
-        override protected bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        override protected bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             if (PermissionsManager.CheckAndWarnPermission(ply, "online"))
             {

--- a/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Trade.cs
+++ b/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Trade.cs
@@ -10,7 +10,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
 
         }
 
-        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        protected override bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             return false;
         }
@@ -23,7 +23,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
 
         }
 
-        override protected bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        override protected bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             Managers.PlayerManager.acceptTrade(ply);
             return true;
@@ -37,7 +37,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
 
         }
 
-        override protected bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        override protected bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             Managers.PlayerManager.rejectTrade(ply);
             return true;
@@ -52,7 +52,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
 
         }
 
-        override protected bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        override protected bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             if (args.Length < 3)
             {
@@ -74,7 +74,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
                 Helpers.Chat.sendSilent(ply, "/trade give <playername> <myitemid> <myitemamount>", Helpers.Chat.ChatColour.orange);
                 return true;
             }
-            Managers.PlayerManager.tradeGive(ply, Players.GetPlayer(target), giveid, giveamt);
+            Managers.PlayerManager.tradeGive(ply, Players.GetPlayer(targets[0]), giveid, giveamt);
             return true;
         }
     }
@@ -86,7 +86,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
 
         }
 
-        override protected bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        override protected bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             if (args.Length < 5)
             {
@@ -117,7 +117,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
                 Helpers.Chat.sendSilent(ply, "/trade send <playername> <myitemid> <myitemamount> <theiritemid> <theiritemamount>", Helpers.Chat.ChatColour.orange);
                 return true;
             }
-            Managers.PlayerManager.notifyTrade(ply, Players.GetPlayer(target), giveid, giveamt, takeid, takeamt);
+            Managers.PlayerManager.notifyTrade(ply, Players.GetPlayer(targets[0]), giveid, giveamt, takeid, takeamt);
             return true;
         }
     }

--- a/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Trash.cs
+++ b/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/Trash.cs
@@ -14,7 +14,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
 
         }
 
-        override protected bool RunCommand(Players.Player ply, string[] args, NetworkID target)
+        override protected bool RunCommand(Players.Player ply, string[] args, NetworkID[] targets)
         {
             ushort itemid = 0;
             int giveamt = 0;

--- a/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/WorldEdit.cs
+++ b/ColonyPlusPlus/ColonyPlusPlus/Classes/CustomChatCommands/WorldEdit.cs
@@ -14,7 +14,7 @@ namespace ColonyPlusPlus.Classes.CustomChatCommands
 
         }
 
-        override protected bool RunCommand(Players.Player player, string[] args, NetworkID target)
+        override protected bool RunCommand(Players.Player player, string[] args, NetworkID[] targets)
         {
             if(args.Length > 0)
             {

--- a/ColonyPlusPlus/ColonyPlusPlus/Classes/Helpers/Chat.cs
+++ b/ColonyPlusPlus/ColonyPlusPlus/Classes/Helpers/Chat.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace ColonyPlusPlus.Classes.Helpers
 {
@@ -129,6 +130,22 @@ namespace ColonyPlusPlus.Classes.Helpers
             }
 
             return stylePrefix + colorPrefix + message + colorSuffix + styleSuffix;
+        }
+
+        /// <summary>
+        /// Splits chat into individual parameters, quoted text becomes 1 parameter
+        /// </summary>
+        /// <param name="chat"></param>
+        /// <param name="prefix"></param>
+        /// <returns>command parameter array</returns>
+        public static string[] ParseChatCommand(this string chat, string prefix)
+        {
+            if (!chat.Contains(" "))
+                return new string[0];
+            
+            chat = chat.Remove(0, prefix.Length);
+
+            return Regex.Split(chat, "(?<=^[^\"]*(?:\"[^\"]*\"[^\"]*)*) (?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)");
         }
     }
 }


### PR DESCRIPTION
I figured this was needed for future commands that require multiple targets without the user having to manually parse them and find them from the args array.

To solve the /tp player1 player2 (teleport player1 to player2) we need this.

I also re-wrote parts of the TryDoCommand in BaseChatCommand.cs to stop using so much hacky string manipulation and instead use regex for simple parsing, this is both easier to read and less performance intensive.